### PR TITLE
Replace asList() DSL method to asInstanceOf(InstanceOfAssertFactories.list(type.class)) instead

### DIFF
--- a/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricherTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.ExecAction;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.Plugin;
@@ -511,14 +512,14 @@ class VertxHealthCheckEnricherTest {
         assertThat(livenessProbe).isNotNull()
             .extracting(Probe::getExec)
             .extracting(ExecAction::getCommand)
-            .asList()
+                .asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .hasSize(3);
 
         Probe readinessProbe = enricher.getReadinessProbe();
         assertThat(readinessProbe).isNotNull()
             .extracting(Probe::getExec)
             .extracting(ExecAction::getCommand)
-            .asList()
+                .asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .hasSize(3);
     }
 
@@ -541,7 +542,7 @@ class VertxHealthCheckEnricherTest {
         Probe readinessProbe = enricher.getReadinessProbe();
         assertThat(readinessProbe).isNotNull()
             .extracting(Probe::getExec)
-            .extracting(ExecAction::getCommand).asList()
+            .extracting(ExecAction::getCommand).asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .hasSize(3);
     }
 
@@ -561,7 +562,7 @@ class VertxHealthCheckEnricherTest {
         Probe livenessProbe = enricher.getLivenessProbe();
         assertThat(livenessProbe).isNotNull()
             .extracting(Probe::getExec)
-            .extracting(ExecAction::getCommand).asList()
+            .extracting(ExecAction::getCommand).asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .hasSize(3);
 
         Probe readinessProbe = enricher.getReadinessProbe();
@@ -670,7 +671,7 @@ class VertxHealthCheckEnricherTest {
         assertThat(livenessProbe).isNotNull()
             .hasFieldOrPropertyWithValue("tcpSocket", null)
             .extracting(Probe::getExec).isNotNull()
-            .extracting(ExecAction::getCommand).asList()
+            .extracting(ExecAction::getCommand).asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .singleElement()
             .isEqualTo("ls");
     }
@@ -690,7 +691,7 @@ class VertxHealthCheckEnricherTest {
         assertThat(readinessProbe).isNotNull()
             .hasFieldOrPropertyWithValue("tcpSocket", null)
             .extracting(Probe::getExec).isNotNull()
-            .extracting(ExecAction::getCommand).asList()
+            .extracting(ExecAction::getCommand).asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .singleElement()
             .isEqualTo("ls");
 
@@ -698,7 +699,7 @@ class VertxHealthCheckEnricherTest {
         assertThat(livenessProbe).isNotNull()
             .hasFieldOrPropertyWithValue("tcpSocket", null)
             .extracting(Probe::getExec).isNotNull()
-            .extracting(ExecAction::getCommand).asList()
+            .extracting(ExecAction::getCommand).asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .singleElement()
             .isEqualTo("ls");
     }

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricherTest.java
@@ -20,7 +20,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.kubernetes.api.model.ContainerFluent;
+import io.fabric8.kubernetes.api.model.*;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Plugin;
@@ -31,9 +32,6 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -281,7 +279,7 @@ class WildflyJARHealthCheckEnricherTest {
         });
 
         assertThat(containerBuilders).singleElement()
-            .extracting(ContainerFluent::buildEnv).asList()
+            .extracting(ContainerFluent::buildEnv).asInstanceOf(InstanceOfAssertFactories.list(EnvVar.class))
             .singleElement()
             .hasFieldOrPropertyWithValue("name", "HOSTNAME")
             .extracting("valueFrom.fieldRef.fieldPath").isNotNull()

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.JavaProject;
@@ -105,7 +106,7 @@ class WildflyJARGeneratorTest {
       assertThat(fileSets).isNotEmpty()
           .last()
           .hasFieldOrPropertyWithValue("directory", targetDir.toFile())
-          .extracting(AssemblyFileSet::getIncludes).asList()
+          .extracting(AssemblyFileSet::getIncludes).asInstanceOf(InstanceOfAssertFactories.list(String.class))
           .singleElement()
           .isEqualTo("myrepo");
     }
@@ -137,7 +138,7 @@ class WildflyJARGeneratorTest {
       assertThat(fileSets).isNotEmpty()
           .last()
           .hasFieldOrPropertyWithValue("directory", targetDir.toFile())
-          .extracting(AssemblyFileSet::getIncludes).asList()
+          .extracting(AssemblyFileSet::getIncludes).asInstanceOf(InstanceOfAssertFactories.list(String.class))
           .singleElement()
           .isEqualTo("myrepo");
     }


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes # (issue)


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
